### PR TITLE
[Feat/#49] 복지로 서비스 추천 표시 여부 변경 API 구현

### DIFF
--- a/src/main/kotlin/kr/io/snuhbmilab/carediaryserverv2/admin/controller/AdminDiaryApi.kt
+++ b/src/main/kotlin/kr/io/snuhbmilab/carediaryserverv2/admin/controller/AdminDiaryApi.kt
@@ -88,4 +88,42 @@ interface AdminDiaryApi {
         @Parameter(description = "작성일 (yyyy-MM-dd)", required = true)
         @RequestParam date: LocalDate
     ): CommonResponse<AdminDiaryFindAllResponse>
+
+    @Operation(
+        summary = "복지 서비스 표시 활성화",
+        description = "특정 일기의 복지 서비스 추천을 사용자에게 표시합니다."
+    )
+    @ApiResponses(
+        value = [
+            ApiResponse(responseCode = "200", description = "복지 서비스 표시 활성화 성공"),
+            ApiResponse(responseCode = "401", description = "인증 실패"),
+            ApiResponse(responseCode = "403", description = "권한 없음"),
+            ApiResponse(responseCode = "404", description = "일기 또는 복지 서비스를 찾을 수 없음")
+        ]
+    )
+    fun updateWelfareServiceVisible(
+        @Parameter(description = "일기 ID", required = true)
+        @PathVariable diaryId: UUID,
+        @Parameter(description = "복지 서비스 ID", required = true)
+        @PathVariable welfareServiceId: Long
+    ): CommonResponse<Unit>
+
+    @Operation(
+        summary = "복지 서비스 표시 비활성화",
+        description = "특정 일기의 복지 서비스 추천을 사용자에게 숨깁니다."
+    )
+    @ApiResponses(
+        value = [
+            ApiResponse(responseCode = "200", description = "복지 서비스 표시 비활성화 성공"),
+            ApiResponse(responseCode = "401", description = "인증 실패"),
+            ApiResponse(responseCode = "403", description = "권한 없음"),
+            ApiResponse(responseCode = "404", description = "일기 또는 복지 서비스를 찾을 수 없음")
+        ]
+    )
+    fun updateWelfareServiceInvisible(
+        @Parameter(description = "일기 ID", required = true)
+        @PathVariable diaryId: UUID,
+        @Parameter(description = "복지 서비스 ID", required = true)
+        @PathVariable welfareServiceId: Long
+    ): CommonResponse<Unit>
 }

--- a/src/main/kotlin/kr/io/snuhbmilab/carediaryserverv2/admin/controller/AdminDiaryController.kt
+++ b/src/main/kotlin/kr/io/snuhbmilab/carediaryserverv2/admin/controller/AdminDiaryController.kt
@@ -6,8 +6,10 @@ import kr.io.snuhbmilab.carediaryserverv2.admin.dto.response.AdminDiarySdohRespo
 import kr.io.snuhbmilab.carediaryserverv2.admin.dto.response.AdminDiaryWelfareServiceResponse
 import kr.io.snuhbmilab.carediaryserverv2.admin.facade.AdminDiaryFacade
 import kr.io.snuhbmilab.carediaryserverv2.common.dto.CommonResponse
+import org.springframework.web.bind.annotation.DeleteMapping
 import org.springframework.web.bind.annotation.GetMapping
 import org.springframework.web.bind.annotation.PathVariable
+import org.springframework.web.bind.annotation.PostMapping
 import org.springframework.web.bind.annotation.RequestMapping
 import org.springframework.web.bind.annotation.RequestParam
 import org.springframework.web.bind.annotation.RestController
@@ -40,5 +42,23 @@ class AdminDiaryController(
         @RequestParam date: LocalDate
     ): CommonResponse<AdminDiaryFindAllResponse> {
         return CommonResponse.ok(adminDiaryFacade.findAllByUserIdAndDate(userId, date))
+    }
+
+    @PostMapping("/{diaryId}/welfare-services/{welfareServiceId}/visible")
+    override fun updateWelfareServiceVisible(
+        @PathVariable diaryId: UUID,
+        @PathVariable welfareServiceId: Long
+    ): CommonResponse<Unit> {
+        adminDiaryFacade.updateWelfareServiceVisible(diaryId, welfareServiceId)
+        return CommonResponse.ok()
+    }
+
+    @DeleteMapping("/{diaryId}/welfare-services/{welfareServiceId}/visible")
+    override fun updateWelfareServiceInvisible(
+        @PathVariable diaryId: UUID,
+        @PathVariable welfareServiceId: Long
+    ): CommonResponse<Unit> {
+        adminDiaryFacade.updateWelfareServiceInvisible(diaryId, welfareServiceId)
+        return CommonResponse.ok()
     }
 }

--- a/src/main/kotlin/kr/io/snuhbmilab/carediaryserverv2/admin/facade/AdminDiaryFacade.kt
+++ b/src/main/kotlin/kr/io/snuhbmilab/carediaryserverv2/admin/facade/AdminDiaryFacade.kt
@@ -50,4 +50,16 @@ class AdminDiaryFacade(
 
         return AdminDiaryFindAllResponse.of(diaries, questionScoresMap)
     }
+
+    @Transactional
+    fun updateWelfareServiceVisible(diaryId: UUID, welfareServiceId: Long) {
+        diaryService.validateExists(diaryId)
+        diaryAnalysisResultService.updateWelfareServiceVisible(diaryId, welfareServiceId)
+    }
+
+    @Transactional
+    fun updateWelfareServiceInvisible(diaryId: UUID, welfareServiceId: Long) {
+        diaryService.validateExists(diaryId)
+        diaryAnalysisResultService.updateWelfareServiceInvisible(diaryId, welfareServiceId)
+    }
 }

--- a/src/main/kotlin/kr/io/snuhbmilab/carediaryserverv2/domain/diary/entity/DiaryWelfareServiceEntity.kt
+++ b/src/main/kotlin/kr/io/snuhbmilab/carediaryserverv2/domain/diary/entity/DiaryWelfareServiceEntity.kt
@@ -68,8 +68,16 @@ class DiaryWelfareServiceEntity(
     val matchedInterestKeywords: String? = null,
 
     @Column(columnDefinition = "TINYINT(1)")
-    val visible: Boolean = false
+    var visible: Boolean = false
 ) : BaseTimeEntity() {
+
+    fun updateVisible() {
+        this.visible = true
+    }
+
+    fun updateInvisible() {
+        this.visible = false
+    }
 
     enum class ServiceScope {
         LOCAL, NATIONAL

--- a/src/main/kotlin/kr/io/snuhbmilab/carediaryserverv2/domain/diary/exception/DiaryErrorCode.kt
+++ b/src/main/kotlin/kr/io/snuhbmilab/carediaryserverv2/domain/diary/exception/DiaryErrorCode.kt
@@ -9,4 +9,5 @@ enum class DiaryErrorCode(
 ) : ErrorCode {
     DIARY_NOT_FOUND(HttpStatus.NOT_FOUND, "일기 정보를 찾을 수 없습니다."),
     DIARY_ACCESS_DENIED(HttpStatus.FORBIDDEN, "일기 정보에 접근할 수 없습니다."),
+    WELFARE_SERVICE_NOT_FOUND(HttpStatus.NOT_FOUND, "복지 서비스 정보를 찾을 수 없습니다."),
 }

--- a/src/main/kotlin/kr/io/snuhbmilab/carediaryserverv2/domain/diary/repository/DiaryWelfareServiceRepository.kt
+++ b/src/main/kotlin/kr/io/snuhbmilab/carediaryserverv2/domain/diary/repository/DiaryWelfareServiceRepository.kt
@@ -9,4 +9,5 @@ interface DiaryWelfareServiceRepository : JpaRepository<DiaryWelfareServiceEntit
     fun findAllByUserAndVisibleIsTrue(user: User): List<DiaryWelfareServiceEntity>
     fun findAllByDiaryId(diaryId: UUID): List<DiaryWelfareServiceEntity>
     fun findTop3ByUserAndVisibleIsTrueOrderByCreatedAtDesc(user: User): List<DiaryWelfareServiceEntity>
+    fun findByDiaryIdAndId(diaryId: UUID, id: Long): DiaryWelfareServiceEntity?
 }

--- a/src/main/kotlin/kr/io/snuhbmilab/carediaryserverv2/domain/diary/service/DiaryAnalysisResultService.kt
+++ b/src/main/kotlin/kr/io/snuhbmilab/carediaryserverv2/domain/diary/service/DiaryAnalysisResultService.kt
@@ -1,9 +1,12 @@
 package kr.io.snuhbmilab.carediaryserverv2.domain.diary.service
 
 import com.fasterxml.jackson.module.kotlin.jacksonObjectMapper
+import kr.io.snuhbmilab.carediaryserverv2.common.exception.BusinessException
 import kr.io.snuhbmilab.carediaryserverv2.common.utils.joinToStringDBText
 import kr.io.snuhbmilab.carediaryserverv2.domain.diary.entity.DiaryAnalysisResult
+import kr.io.snuhbmilab.carediaryserverv2.domain.diary.entity.DiaryWelfareServiceEntity
 import kr.io.snuhbmilab.carediaryserverv2.domain.diary.entity.Pie
+import kr.io.snuhbmilab.carediaryserverv2.domain.diary.exception.DiaryErrorCode
 import kr.io.snuhbmilab.carediaryserverv2.domain.diary.repository.DiaryAnalysisResultRepository
 import kr.io.snuhbmilab.carediaryserverv2.domain.diary.repository.DiaryKeywordExtractionRepository
 import kr.io.snuhbmilab.carediaryserverv2.domain.diary.repository.DiaryWelfareServiceRepository
@@ -26,6 +29,23 @@ class DiaryAnalysisResultService(
 
     fun findAllKeywordExtractions(diaryId: UUID) = diaryKeywordExtractionRepository.findAllByDiaryId(diaryId)
     fun findAllWelfareServices(diaryId: UUID) = diaryWelfareServiceRepository.findAllByDiaryId(diaryId)
+
+    fun findWelfareService(diaryId: UUID, welfareServiceId: Long): DiaryWelfareServiceEntity {
+        return diaryWelfareServiceRepository.findByDiaryIdAndId(diaryId, welfareServiceId)
+            ?: throw BusinessException(DiaryErrorCode.WELFARE_SERVICE_NOT_FOUND)
+    }
+
+    @Transactional
+    fun updateWelfareServiceVisible(diaryId: UUID, welfareServiceId: Long) {
+        val welfareService = findWelfareService(diaryId, welfareServiceId)
+        welfareService.updateVisible()
+    }
+
+    @Transactional
+    fun updateWelfareServiceInvisible(diaryId: UUID, welfareServiceId: Long) {
+        val welfareService = findWelfareService(diaryId, welfareServiceId)
+        welfareService.updateInvisible()
+    }
 
     fun countAll(): Long = diaryAnalysisResultRepository.count()
 


### PR DESCRIPTION
## #️⃣연관된 이슈

> ex) #이슈번호, #이슈번호
#49 

## 📝작업 내용

> 이번 PR에서 작업한 내용을 간략히 설명해주세요(이미지 첨부 가능)

1. DiaryWelfareServiceEntity

- visible 필드를 var로 변경하여 수정 가능하게 함
- updateVisible(), updateInvisible() 메서드 추가

2. DiaryWelfareServiceRepository

- findByDiaryIdAndId(diaryId, id) 메서드 추가

3. DiaryErrorCode

- WELFARE_SERVICE_NOT_FOUND 에러 코드 추가

4. DiaryAnalysisResultService

- findWelfareService() 메서드 추가
- updateWelfareServiceVisible(), updateWelfareServiceInvisible() 메서드 추가

5. AdminDiaryFacade

- updateWelfareServiceVisible(), updateWelfareServiceInvisible() 메서드 추가

6. AdminDiaryApi / AdminDiaryController

- [POST] /v1/admin/diaries/{diaryId}/welfare-services/{welfareServiceId}/visible - 활성화
- [DELETE] /v1/admin/diaries/{diaryId}/welfare-services/{welfareServiceId}/visible - 비활성화

### 스크린샷 (선택)

## 💬리뷰 요구사항(선택)

> 리뷰어가 특별히 봐주었으면 하는 부분이 있다면 작성해주세요
>
> ex) 메서드 XXX의 이름을 더 잘 짓고 싶은데 혹시 좋은 명칭이 있을까요?


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 릴리스 노트

* **새 기능**
  * 관리자가 일기에 연결된 복지 서비스의 표시/숨김 상태를 관리할 수 있는 새로운 기능 추가
  * 복지 서비스를 표시 상태로 전환하는 기능
  * 복지 서비스를 숨김 상태로 전환하는 기능

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->