### PR TITLE
[Feat/#51] 일기 분석 결과 저장 시에도 위험군 식별이 작동하도록 구현

### DIFF
--- a/src/main/kotlin/kr/io/snuhbmilab/carediaryserverv2/admin/dto/response/AdminDiaryFindAllResponse.kt
+++ b/src/main/kotlin/kr/io/snuhbmilab/carediaryserverv2/admin/dto/response/AdminDiaryFindAllResponse.kt
@@ -59,7 +59,7 @@ data class AdminDiaryFindAllResponse(
                 questionScores: List<DiaryRecommendedQuestionUserScore>
             ) = AdminDiaryDto(
                 diaryId = diary.id!!,
-                uploaderId = diary.uploader.id!!,
+                uploaderId = diary.uploaderId,
                 date = diary.date,
                 content = diary.content,
                 emotion = diary.emotion,

--- a/src/main/kotlin/kr/io/snuhbmilab/carediaryserverv2/domain/diary/entity/Diary.kt
+++ b/src/main/kotlin/kr/io/snuhbmilab/carediaryserverv2/domain/diary/entity/Diary.kt
@@ -25,9 +25,12 @@ class Diary(
     @Column(name = "diary_id", nullable = false)
     val id: UUID? = null,
 
+    @Column(name = "uploader_id", nullable = false)
+    val uploaderId: UUID,
+
     @ManyToOne(fetch = FetchType.LAZY)
-    @JoinColumn(name = "uploader_id", nullable = false)
-    val uploader: User,
+    @JoinColumn(name = "uploader_id", insertable = false, updatable = false)
+    val uploader: User? = null,
 
     @Column(name = "date", nullable = false)
     val date: LocalDate,

--- a/src/main/kotlin/kr/io/snuhbmilab/carediaryserverv2/domain/diary/event/DiaryAnalysisResultSavedEvent.kt
+++ b/src/main/kotlin/kr/io/snuhbmilab/carediaryserverv2/domain/diary/event/DiaryAnalysisResultSavedEvent.kt
@@ -1,0 +1,8 @@
+package kr.io.snuhbmilab.carediaryserverv2.domain.diary.event
+
+import java.util.UUID
+
+data class DiaryAnalysisResultSavedEvent(
+    val diaryId: UUID,
+    val uploaderId: UUID,
+)

--- a/src/main/kotlin/kr/io/snuhbmilab/carediaryserverv2/domain/diary/facade/DiaryFacade.kt
+++ b/src/main/kotlin/kr/io/snuhbmilab/carediaryserverv2/domain/diary/facade/DiaryFacade.kt
@@ -95,7 +95,7 @@ class DiaryFacade(
     }
 
     private fun validateDiaryUploader(user: User, diary: Diary) {
-        if (user.id != diary.uploader.id) {
+        if (user.id != diary.uploaderId) {
             throw BusinessException(DiaryErrorCode.DIARY_ACCESS_DENIED)
         }
     }

--- a/src/main/kotlin/kr/io/snuhbmilab/carediaryserverv2/domain/diary/service/DiaryAnalysisResultService.kt
+++ b/src/main/kotlin/kr/io/snuhbmilab/carediaryserverv2/domain/diary/service/DiaryAnalysisResultService.kt
@@ -66,7 +66,7 @@ class DiaryAnalysisResultService(
     @Transactional
     fun saveAnalysisResult(response: DiaryAnalysisResponse) {
         val diaryId = response.diaryId
-        val diary = diaryService.findById(response.diaryId)
+        val diary = diaryService.findById(diaryId)
 
         val fullOutputText = objectMapper.writeValueAsString(response)
 

--- a/src/main/kotlin/kr/io/snuhbmilab/carediaryserverv2/domain/diary/service/DiaryService.kt
+++ b/src/main/kotlin/kr/io/snuhbmilab/carediaryserverv2/domain/diary/service/DiaryService.kt
@@ -20,7 +20,7 @@ class DiaryService(
     fun create(user: User, date: LocalDate, content: String, emotion: Diary.Emotion): Diary =
         diaryRepository.save(
             Diary(
-                uploader = user,
+                uploaderId = user.id!!,
                 date = date,
                 content = content,
                 emotion = emotion

--- a/src/main/kotlin/kr/io/snuhbmilab/carediaryserverv2/domain/user/event/listener/UserRiskEvaluateListener.kt
+++ b/src/main/kotlin/kr/io/snuhbmilab/carediaryserverv2/domain/user/event/listener/UserRiskEvaluateListener.kt
@@ -2,6 +2,7 @@ package kr.io.snuhbmilab.carediaryserverv2.domain.user.event.listener
 
 import io.github.oshai.kotlinlogging.KotlinLogging
 import kr.io.snuhbmilab.carediaryserverv2.common.constants.ThreadPoolNames
+import kr.io.snuhbmilab.carediaryserverv2.domain.diary.event.DiaryAnalysisResultSavedEvent
 import kr.io.snuhbmilab.carediaryserverv2.domain.scalequestion.event.UserScaleQuestionResultRegisterEvent
 import kr.io.snuhbmilab.carediaryserverv2.domain.user.service.UserRiskEvaluator
 import org.springframework.scheduling.annotation.Async
@@ -19,6 +20,18 @@ class UserRiskEvaluateListener(
     @TransactionalEventListener(phase = TransactionPhase.AFTER_COMMIT)
     fun onScaleQuestionResultRegistered(event: UserScaleQuestionResultRegisterEvent) {
         val userId = event.userId
+
+        try {
+            userRiskEvaluator.evaluate(userId)
+        } catch(exception: Exception) {
+            logger.error(exception) { "사용자 위험군 판별 실패 userId=$userId" }
+        }
+    }
+
+    @Async(ThreadPoolNames.USER_RISK_EVALUATION)
+    @TransactionalEventListener(phase = TransactionPhase.AFTER_COMMIT)
+    fun onDiaryAnalysisResultSaved(event: DiaryAnalysisResultSavedEvent) {
+        val userId = event.uploaderId
 
         try {
             userRiskEvaluator.evaluate(userId)


### PR DESCRIPTION
## #️⃣연관된 이슈

> ex) #이슈번호, #이슈번호

#51 

## 📝작업 내용

> 이번 PR에서 작업한 내용을 간략히 설명해주세요(이미지 첨부 가능)

- 일기 분석 결과 저장 시에도 위험군 식별이 작동하도록 구현하여 심각성이 4 이상인 경우도 식별할 수 있도록 수정하였습니다.

### 스크린샷 (선택)

## 💬리뷰 요구사항(선택)

> 리뷰어가 특별히 봐주었으면 하는 부분이 있다면 작성해주세요
>
> ex) 메서드 XXX의 이름을 더 잘 짓고 싶은데 혹시 좋은 명칭이 있을까요?


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## 릴리스 노트

* **새로운 기능**
  * 일기 분석 결과가 저장되면 관련 이벤트가 발행되어 사용자 위험도 평가가 자동으로 실행됩니다.

* **개선 사항**
  * 일기 작성자 식별 및 권한 검증 방식이 개선되어 일기 관련 처리 흐름의 일관성과 안정성이 향상되었습니다.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->