### PR TITLE
[Feat/#55] 분노/우울 척도 카테고리 분리

### DIFF
--- a/src/main/kotlin/kr/io/snuhbmilab/carediaryserverv2/admin/dto/response/AdminUserScaleFindAllResponse.kt
+++ b/src/main/kotlin/kr/io/snuhbmilab/carediaryserverv2/admin/dto/response/AdminUserScaleFindAllResponse.kt
@@ -9,14 +9,14 @@ import java.time.LocalDateTime
 data class AdminUserScaleFindAllResponse(
     @Schema(
         description = "회차별 척도 결과 (키: 회차 번호, 값: 해당 회차의 척도 점수 목록)",
-        example = "{\"1\": [{\"scaleCategory\": \"ANXIETY_DEPRESSION\", \"score\": 8, \"createdAt\": \"2024-01-15T10:30:00\"}], \"2\": [{\"scaleCategory\": \"ANGER\", \"score\": 10, \"createdAt\": \"2024-02-15T10:30:00\"}]}"
+        example = "{\"1\": [{\"scaleCategory\": \"ANXIETY\", \"score\": 8, \"createdAt\": \"2024-01-15T10:30:00\"}, {\"scaleCategory\": \"DEPRESSION\", \"score\": 6, \"createdAt\": \"2024-01-15T10:30:00\"}], \"2\": [{\"scaleCategory\": \"ANGER\", \"score\": 10, \"createdAt\": \"2024-02-15T10:30:00\"}]}"
     )
     val items: Map<String, List<UserScaleItem>>
 ) {
 
     @Schema(description = "사용자 척도 점수 항목")
     data class UserScaleItem(
-        @Schema(description = "척도 카테고리 (ANXIETY_DEPRESSION: 불안/우울, ANGER: 분노)", example = "ANXIETY_DEPRESSION")
+        @Schema(description = "척도 카테고리 (ANXIETY: 불안, DEPRESSION: 우울, ANGER: 분노)", example = "ANXIETY")
         val scaleCategory: ScaleCategory,
 
         @Schema(description = "척도 점수", example = "12")

--- a/src/main/kotlin/kr/io/snuhbmilab/carediaryserverv2/admin/dto/response/AdminUserScaleQuestionResultResponse.kt
+++ b/src/main/kotlin/kr/io/snuhbmilab/carediaryserverv2/admin/dto/response/AdminUserScaleQuestionResultResponse.kt
@@ -27,7 +27,7 @@ data class AdminUserScaleQuestionResultResponse(
     @Schema(description = "척도 질문 응답 회차", example = "3")
     val scaleQuestionTermCount: Int,
 
-    @Schema(description = "척도 카테고리별 질문 응답 결과 (키: ANXIETY_DEPRESSION/ANGER)")
+    @Schema(description = "척도 카테고리별 질문 응답 결과 (키: ANXIETY/DEPRESSION/ANGER)")
     val items: Map<ScaleCategory, ScaleQuestionResultDto>
 ) {
 
@@ -59,7 +59,7 @@ data class AdminUserScaleQuestionResultResponse(
 
     @Schema(description = "척도 질문 결과 정보")
     data class ScaleQuestionResultDto(
-        @Schema(description = "척도 카테고리 (ANXIETY_DEPRESSION: 불안/우울, ANGER: 분노)", example = "ANXIETY_DEPRESSION")
+        @Schema(description = "척도 카테고리 (ANXIETY: 불안, DEPRESSION: 우울, ANGER: 분노)", example = "ANXIETY")
         val scaleCategory: ScaleCategory,
 
         @Schema(description = "해당 척도의 총점", example = "15")

--- a/src/main/kotlin/kr/io/snuhbmilab/carediaryserverv2/domain/scalequestion/constants/ScaleCategory.kt
+++ b/src/main/kotlin/kr/io/snuhbmilab/carediaryserverv2/domain/scalequestion/constants/ScaleCategory.kt
@@ -1,5 +1,5 @@
 package kr.io.snuhbmilab.carediaryserverv2.domain.scalequestion.constants
 
 enum class ScaleCategory {
-    ANXIETY_DEPRESSION, ANGER
+    ANXIETY, DEPRESSION, ANGER
 }

--- a/src/main/kotlin/kr/io/snuhbmilab/carediaryserverv2/domain/scalequestion/dto/response/ScaleQuestionFindAllResponse.kt
+++ b/src/main/kotlin/kr/io/snuhbmilab/carediaryserverv2/domain/scalequestion/dto/response/ScaleQuestionFindAllResponse.kt
@@ -21,7 +21,7 @@ data class ScaleQuestionFindAllResponse(
         @Schema(description = "질문 내용", example = "지난 일주일 동안 긴장되거나 불안했다")
         val content: String,
 
-        @Schema(description = "척도 카테고리 (ANXIETY_DEPRESSION, ANGER)", example = "ANXIETY_DEPRESSION")
+        @Schema(description = "척도 카테고리 (ANXIETY, DEPRESSION, ANGER)", example = "ANXIETY")
         val scaleCategory: ScaleCategory,
 
         @Schema(description = "선택지 개수", example = "5")

--- a/src/main/kotlin/kr/io/snuhbmilab/carediaryserverv2/domain/scalequestion/dto/response/UserScaleFindAllResponse.kt
+++ b/src/main/kotlin/kr/io/snuhbmilab/carediaryserverv2/domain/scalequestion/dto/response/UserScaleFindAllResponse.kt
@@ -8,14 +8,14 @@ import kr.io.snuhbmilab.carediaryserverv2.domain.scalequestion.entity.UserScale
 data class UserScaleFindAllResponse(
     @Schema(
         description = "회차별 척도 결과 (키: 회차 번호, 값: 해당 회차의 척도 점수 목록)",
-        example = "{\"0\": [{\"scaleCategory\": \"ANXIETY_DEPRESSION\", \"score\": 12}, {\"scaleCategory\": \"ANGER\", \"score\": 8}]}"
+        example = "{\"0\": [{\"scaleCategory\": \"ANXIETY\", \"score\": 12}, {\"scaleCategory\": \"DEPRESSION\", \"score\": 10}, {\"scaleCategory\": \"ANGER\", \"score\": 8}]}"
     )
     val items: Map<String, List<UserScaleItem>>
 ) {
 
     @Schema(description = "사용자 척도 점수 항목")
     data class UserScaleItem(
-        @Schema(description = "척도 카테고리 (ANXIETY_DEPRESSION, ANGER)", example = "ANGER")
+        @Schema(description = "척도 카테고리 (ANXIETY, DEPRESSION, ANGER)", example = "ANXIETY")
         val scaleCategory: ScaleCategory,
 
         @Schema(description = "척도 점수", example = "12")


### PR DESCRIPTION
## #️⃣연관된 이슈

> ex) #이슈번호, #이슈번호

#55 

## 📝작업 내용

> 이번 PR에서 작업한 내용을 간략히 설명해주세요(이미지 첨부 가능)

- 수정된 요구사항을 반영하여 분노/우울 척도 분류를 분노, 우울 척도로 분리하였습니다.
  - ANXIETY_DEPRESSION -> ANXIETY, DEPRESSION  

### 스크린샷 (선택)

## 💬리뷰 요구사항(선택)

> 리뷰어가 특별히 봐주었으면 하는 부분이 있다면 작성해주세요
>
> ex) 메서드 XXX의 이름을 더 잘 짓고 싶은데 혹시 좋은 명칭이 있을까요?


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 릴리스 노트

* **Refactor**
  * 정신건강 평가 척도에서 불안/우울 항목을 분리하여 불안, 우울, 분노로 개별 카테고리화했습니다.
  * 척도 항목 구조를 업데이트하여 더욱 명확한 평가 항목 분류 체계를 제공합니다.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->