### PR TITLE
[Feat/#61] 사용자별 일기 추출 워드클라우드 조회 API 구현

### DIFF
--- a/src/main/kotlin/kr/io/snuhbmilab/carediaryserverv2/admin/controller/AdminUserApi.kt
+++ b/src/main/kotlin/kr/io/snuhbmilab/carediaryserverv2/admin/controller/AdminUserApi.kt
@@ -11,6 +11,7 @@ import kr.io.snuhbmilab.carediaryserverv2.admin.dto.response.AdminUserDetailResp
 import kr.io.snuhbmilab.carediaryserverv2.admin.dto.response.AdminUserFindAllResponse
 import kr.io.snuhbmilab.carediaryserverv2.admin.dto.response.AdminUserScaleFindAllResponse
 import kr.io.snuhbmilab.carediaryserverv2.admin.dto.response.AdminUserScaleQuestionResultResponse
+import kr.io.snuhbmilab.carediaryserverv2.admin.dto.response.AdminUserWordCloudResponse
 import org.springframework.web.bind.annotation.PathVariable
 import org.springframework.web.bind.annotation.RequestParam
 import java.util.UUID
@@ -85,4 +86,21 @@ interface AdminUserApi {
         @Parameter(description = "조회할 회차", required = true, example = "1")
         @RequestParam count: Int
     ): CommonResponse<AdminUserScaleQuestionResultResponse>
+
+    @Operation(
+        summary = "사용자 워드클라우드 조회",
+        description = "특정 사용자의 일기에서 추출한 워드클라우드 데이터를 조회합니다."
+    )
+    @ApiResponses(
+        value = [
+            ApiResponse(responseCode = "200", description = "워드클라우드 조회 성공"),
+            ApiResponse(responseCode = "401", description = "인증 실패"),
+            ApiResponse(responseCode = "403", description = "권한 없음"),
+            ApiResponse(responseCode = "404", description = "사용자를 찾을 수 없음")
+        ]
+    )
+    fun findUserWordCloud(
+        @Parameter(description = "사용자 ID", required = true)
+        @PathVariable userId: UUID
+    ): CommonResponse<AdminUserWordCloudResponse>
 }

--- a/src/main/kotlin/kr/io/snuhbmilab/carediaryserverv2/admin/controller/AdminUserController.kt
+++ b/src/main/kotlin/kr/io/snuhbmilab/carediaryserverv2/admin/controller/AdminUserController.kt
@@ -4,6 +4,7 @@ import kr.io.snuhbmilab.carediaryserverv2.admin.dto.response.AdminUserDetailResp
 import kr.io.snuhbmilab.carediaryserverv2.admin.dto.response.AdminUserFindAllResponse
 import kr.io.snuhbmilab.carediaryserverv2.admin.dto.response.AdminUserScaleFindAllResponse
 import kr.io.snuhbmilab.carediaryserverv2.admin.dto.response.AdminUserScaleQuestionResultResponse
+import kr.io.snuhbmilab.carediaryserverv2.admin.dto.response.AdminUserWordCloudResponse
 import kr.io.snuhbmilab.carediaryserverv2.admin.facade.AdminUserFacade
 import kr.io.snuhbmilab.carediaryserverv2.common.dto.CommonResponse
 import org.springframework.web.bind.annotation.GetMapping
@@ -36,5 +37,10 @@ class AdminUserController(
     @GetMapping("/{userId}/scale-questions")
     override fun findScaleQuestionResult(@PathVariable userId: UUID, @RequestParam count: Int): CommonResponse<AdminUserScaleQuestionResultResponse> {
         return CommonResponse.ok(adminUserFacade.findScaleQuestionResult(userId, count))
+    }
+
+    @GetMapping("/{userId}/wordcloud")
+    override fun findUserWordCloud(@PathVariable userId: UUID): CommonResponse<AdminUserWordCloudResponse> {
+        return CommonResponse.ok(adminUserFacade.findUserWordCloud(userId))
     }
 }

--- a/src/main/kotlin/kr/io/snuhbmilab/carediaryserverv2/admin/dto/response/AdminUserWordCloudResponse.kt
+++ b/src/main/kotlin/kr/io/snuhbmilab/carediaryserverv2/admin/dto/response/AdminUserWordCloudResponse.kt
@@ -1,0 +1,40 @@
+package kr.io.snuhbmilab.carediaryserverv2.admin.dto.response
+
+import io.swagger.v3.oas.annotations.media.Schema
+import kr.io.snuhbmilab.carediaryserverv2.external.model.dto.GenerateWordCloudResponse
+import java.util.UUID
+
+@Schema(description = "관리자 사용자 워드클라우드 조회 결과")
+data class AdminUserWordCloudResponse(
+    @Schema(description = "사용자 ID", example = "550e8400-e29b-41d4-a716-446655440000")
+    val userId: UUID,
+
+    @Schema(description = "분석에 사용된 일기 개수", example = "30")
+    val totalDiaries: Int,
+
+    @Schema(description = "전체 단어 총합", example = "2150")
+    val totalTokens: Int,
+
+    @Schema(description = "상위 단어 목록")
+    val items: List<WordCloudItemDto>
+) {
+    companion object {
+        fun from(response: GenerateWordCloudResponse): AdminUserWordCloudResponse {
+            return AdminUserWordCloudResponse(
+                userId = response.userId,
+                totalDiaries = response.totalDiaries,
+                totalTokens = response.totalTokens,
+                items = response.items.map { WordCloudItemDto(it.word, it.count) }
+            )
+        }
+    }
+
+    @Schema(description = "워드클라우드 단어 항목")
+    data class WordCloudItemDto(
+        @Schema(description = "단어", example = "병원")
+        val word: String,
+
+        @Schema(description = "등장 횟수", example = "32")
+        val count: Int
+    )
+}

--- a/src/main/kotlin/kr/io/snuhbmilab/carediaryserverv2/admin/facade/AdminUserFacade.kt
+++ b/src/main/kotlin/kr/io/snuhbmilab/carediaryserverv2/admin/facade/AdminUserFacade.kt
@@ -4,11 +4,14 @@ import kr.io.snuhbmilab.carediaryserverv2.admin.dto.response.AdminUserDetailResp
 import kr.io.snuhbmilab.carediaryserverv2.admin.dto.response.AdminUserFindAllResponse
 import kr.io.snuhbmilab.carediaryserverv2.admin.dto.response.AdminUserScaleFindAllResponse
 import kr.io.snuhbmilab.carediaryserverv2.admin.dto.response.AdminUserScaleQuestionResultResponse
+import kr.io.snuhbmilab.carediaryserverv2.admin.dto.response.AdminUserWordCloudResponse
 import kr.io.snuhbmilab.carediaryserverv2.domain.diary.service.DiaryService
 import kr.io.snuhbmilab.carediaryserverv2.domain.scalequestion.service.ScaleQuestionService
 import kr.io.snuhbmilab.carediaryserverv2.domain.scalequestion.service.UserScaleService
 import kr.io.snuhbmilab.carediaryserverv2.domain.user.service.UserRiskService
 import kr.io.snuhbmilab.carediaryserverv2.domain.user.service.UserService
+import kr.io.snuhbmilab.carediaryserverv2.external.model.ModelClient
+import kr.io.snuhbmilab.carediaryserverv2.external.model.dto.GenerateWordCloudRequest
 import org.springframework.stereotype.Service
 import org.springframework.transaction.annotation.Transactional
 import java.time.Year
@@ -23,6 +26,7 @@ class AdminUserFacade(
     private val userScaleService: UserScaleService,
     private val scaleQuestionService: ScaleQuestionService,
     private val userRiskService: UserRiskService,
+    private val modelClient: ModelClient,
 ) {
     fun findUserById(userId: UUID): AdminUserDetailResponse {
         val user = userService.findById(userId)
@@ -63,5 +67,16 @@ class AdminUserFacade(
         }
 
         return AdminUserFindAllResponse.from(userEvaluations)
+    }
+
+    fun findUserWordCloud(userId: UUID): AdminUserWordCloudResponse {
+        val request = GenerateWordCloudRequest(
+            userId = userId,
+            topK = 20,
+            maxDiaries = null
+        )
+        val response = modelClient.generateWordCloud(request).body!!
+
+        return AdminUserWordCloudResponse.from(response)
     }
 }

--- a/src/main/kotlin/kr/io/snuhbmilab/carediaryserverv2/external/model/ModelClient.kt
+++ b/src/main/kotlin/kr/io/snuhbmilab/carediaryserverv2/external/model/ModelClient.kt
@@ -2,6 +2,8 @@ package kr.io.snuhbmilab.carediaryserverv2.external.model
 
 import kr.io.snuhbmilab.carediaryserverv2.external.model.dto.GenerateSummaryRequest
 import kr.io.snuhbmilab.carediaryserverv2.external.model.dto.GenerateSummaryResponse
+import kr.io.snuhbmilab.carediaryserverv2.external.model.dto.GenerateWordCloudRequest
+import kr.io.snuhbmilab.carediaryserverv2.external.model.dto.GenerateWordCloudResponse
 import org.springframework.cloud.openfeign.FeignClient
 import org.springframework.http.ResponseEntity
 import org.springframework.web.bind.annotation.PostMapping
@@ -11,4 +13,7 @@ import org.springframework.web.bind.annotation.RequestBody
 interface ModelClient {
     @PostMapping("/summary")
     fun generateSummary(@RequestBody request: GenerateSummaryRequest): ResponseEntity<GenerateSummaryResponse>
+
+    @PostMapping("/wordcloud")
+    fun generateWordCloud(@RequestBody request: GenerateWordCloudRequest): ResponseEntity<GenerateWordCloudResponse>
 }

--- a/src/main/kotlin/kr/io/snuhbmilab/carediaryserverv2/external/model/dto/GenerateWordCloudRequest.kt
+++ b/src/main/kotlin/kr/io/snuhbmilab/carediaryserverv2/external/model/dto/GenerateWordCloudRequest.kt
@@ -1,0 +1,13 @@
+package kr.io.snuhbmilab.carediaryserverv2.external.model.dto
+
+import com.fasterxml.jackson.annotation.JsonProperty
+import java.util.UUID
+
+data class GenerateWordCloudRequest(
+    @JsonProperty("user_id")
+    val userId: UUID,
+    @JsonProperty("top_k")
+    val topK: Int,
+    @JsonProperty("max_diaries")
+    val maxDiaries: Int?
+)

--- a/src/main/kotlin/kr/io/snuhbmilab/carediaryserverv2/external/model/dto/GenerateWordCloudResponse.kt
+++ b/src/main/kotlin/kr/io/snuhbmilab/carediaryserverv2/external/model/dto/GenerateWordCloudResponse.kt
@@ -1,0 +1,19 @@
+package kr.io.snuhbmilab.carediaryserverv2.external.model.dto
+
+import com.fasterxml.jackson.annotation.JsonProperty
+import java.util.UUID
+
+data class GenerateWordCloudResponse(
+    @JsonProperty("user_id")
+    val userId: UUID,
+    @JsonProperty("total_diaries")
+    val totalDiaries: Int,
+    @JsonProperty("total_tokens")
+    val totalTokens: Int,
+    val items: List<WordCloudItem>
+) {
+    data class WordCloudItem(
+        val word: String,
+        val count: Int
+    )
+}


### PR DESCRIPTION
## #️⃣연관된 이슈

> ex) #이슈번호, #이슈번호

## 📝작업 내용

> 이번 PR에서 작업한 내용을 간략히 설명해주세요(이미지 첨부 가능)

  - 관리자가 특정 사용자의 일기 데이터를 기반으로 워드클라우드를 조회할 수 있는 API를 추가했습니다.
                                                                          
  - 엔드포인트                                                
    - [GET] /v1/admin/users/{userId}/wordcloud

  - External (외부 API 연동)
    - GenerateWordCloudRequest.kt — 워드클라우드 요청 DTO (userId, topK, maxDiaries)
    - GenerateWordCloudResponse.kt — 워드클라우드 응답 DTO (userId, totalDiaries, totalTokens, items)
    - ModelClient.kt — POST /wordcloud Feign 메서드 추가

  - Admin (관리자 API)
    - AdminUserWordCloudResponse.kt — 관리자용 응답 DTO
    - AdminUserApi.kt — Swagger 문서화 인터페이스 추가
    - AdminUserController.kt — GET /{userId}/wordcloud 엔드포인트 구현
    - AdminUserFacade.kt — ModelClient 호출 및 응답 변환 로직

### 스크린샷 (선택)

## 💬리뷰 요구사항(선택)

> 리뷰어가 특별히 봐주었으면 하는 부분이 있다면 작성해주세요
>
> ex) 메서드 XXX의 이름을 더 잘 짓고 싶은데 혹시 좋은 명칭이 있을까요?


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 릴리스 노트

* **New Features**
  * 관리자용 단어 구름 조회 기능 추가: 사용자의 일기 데이터를 분석하여 자주 사용된 단어를 시각적으로 표현합니다. 상위 단어 및 빈도 통계와 함께 제공됩니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->