### PR TITLE
[Feat/#63] 관리자 역할별 인증 방식 변경

### DIFF
--- a/src/main/kotlin/kr/io/snuhbmilab/carediaryserverv2/admin/controller/AdminUserApi.kt
+++ b/src/main/kotlin/kr/io/snuhbmilab/carediaryserverv2/admin/controller/AdminUserApi.kt
@@ -6,6 +6,7 @@ import io.swagger.v3.oas.annotations.responses.ApiResponse
 import io.swagger.v3.oas.annotations.responses.ApiResponses
 import io.swagger.v3.oas.annotations.security.SecurityRequirement
 import io.swagger.v3.oas.annotations.tags.Tag
+import kr.io.snuhbmilab.carediaryserverv2.common.annotation.UserId
 import kr.io.snuhbmilab.carediaryserverv2.common.dto.CommonResponse
 import kr.io.snuhbmilab.carediaryserverv2.admin.dto.response.AdminUserDetailResponse
 import kr.io.snuhbmilab.carediaryserverv2.admin.dto.response.AdminUserFindAllResponse
@@ -30,7 +31,7 @@ interface AdminUserApi {
             ApiResponse(responseCode = "403", description = "권한 없음")
         ]
     )
-    fun findAllUsers(): CommonResponse<AdminUserFindAllResponse>
+    fun findAllUsers(@UserId userId: UUID): CommonResponse<AdminUserFindAllResponse>
 
     @Operation(
         summary = "사용자 상세 조회",

--- a/src/main/kotlin/kr/io/snuhbmilab/carediaryserverv2/admin/controller/AdminUserController.kt
+++ b/src/main/kotlin/kr/io/snuhbmilab/carediaryserverv2/admin/controller/AdminUserController.kt
@@ -5,6 +5,7 @@ import kr.io.snuhbmilab.carediaryserverv2.admin.dto.response.AdminUserFindAllRes
 import kr.io.snuhbmilab.carediaryserverv2.admin.dto.response.AdminUserScaleFindAllResponse
 import kr.io.snuhbmilab.carediaryserverv2.admin.dto.response.AdminUserScaleQuestionResultResponse
 import kr.io.snuhbmilab.carediaryserverv2.admin.facade.AdminUserFacade
+import kr.io.snuhbmilab.carediaryserverv2.common.annotation.UserId
 import kr.io.snuhbmilab.carediaryserverv2.common.dto.CommonResponse
 import org.springframework.web.bind.annotation.GetMapping
 import org.springframework.web.bind.annotation.PathVariable
@@ -19,8 +20,8 @@ class AdminUserController(
     private val adminUserFacade: AdminUserFacade
 ) : AdminUserApi {
     @GetMapping
-    override fun findAllUsers(): CommonResponse<AdminUserFindAllResponse> {
-        return CommonResponse.ok(adminUserFacade.findAllUsers())
+    override fun findAllUsers(@UserId userId: UUID): CommonResponse<AdminUserFindAllResponse> {
+        return CommonResponse.ok(adminUserFacade.findAllUsers(userId))
     }
 
     @GetMapping("/{userId}")

--- a/src/main/kotlin/kr/io/snuhbmilab/carediaryserverv2/admin/facade/AdminUserFacade.kt
+++ b/src/main/kotlin/kr/io/snuhbmilab/carediaryserverv2/admin/facade/AdminUserFacade.kt
@@ -4,6 +4,7 @@ import kr.io.snuhbmilab.carediaryserverv2.admin.dto.response.AdminUserDetailResp
 import kr.io.snuhbmilab.carediaryserverv2.admin.dto.response.AdminUserFindAllResponse
 import kr.io.snuhbmilab.carediaryserverv2.admin.dto.response.AdminUserScaleFindAllResponse
 import kr.io.snuhbmilab.carediaryserverv2.admin.dto.response.AdminUserScaleQuestionResultResponse
+import kr.io.snuhbmilab.carediaryserverv2.common.constants.Role
 import kr.io.snuhbmilab.carediaryserverv2.domain.diary.service.DiaryService
 import kr.io.snuhbmilab.carediaryserverv2.domain.scalequestion.service.ScaleQuestionService
 import kr.io.snuhbmilab.carediaryserverv2.domain.scalequestion.service.UserScaleService
@@ -50,9 +51,15 @@ class AdminUserFacade(
         return AdminUserScaleQuestionResultResponse.of(user, userScales, userAnswerMap)
     }
 
-    fun findAllUsers(): AdminUserFindAllResponse {
-        val users = userService.findAllRegistered()
-            .filterNot { it.isAdmin() }
+    fun findAllUsers(userId: UUID): AdminUserFindAllResponse {
+        val currentUser = userService.findById(userId)
+
+        val users = when (currentUser.role) {
+            Role.ADMIN -> userService.findAllByRole(Role.USER)
+            Role.CARE_MANAGER -> userService.findAllByRoleAndManagerId(Role.USER, currentUser.id!!)
+            else -> emptyList()
+        }
+
         val riskEvaluations = userRiskService.findAllByUserIds(users.map { it.id!! })
             .groupBy { it.userId }
 

--- a/src/main/kotlin/kr/io/snuhbmilab/carediaryserverv2/common/config/SecurityConfig.kt
+++ b/src/main/kotlin/kr/io/snuhbmilab/carediaryserverv2/common/config/SecurityConfig.kt
@@ -53,7 +53,7 @@ class SecurityConfig(
             .sessionManagement { it.sessionCreationPolicy(SessionCreationPolicy.STATELESS) }
             .authorizeHttpRequests {
                 it.requestMatchers(*WHITELIST_ENDPOINTS).permitAll()
-                    .requestMatchers(ADMIN_ENDPOINT).hasAnyRole(Role.ADMIN.name)
+                    .requestMatchers(ADMIN_ENDPOINT).hasAnyRole(Role.ADMIN.name, Role.CARE_MANAGER.name)
                     .anyRequest().authenticated()
             }
             .exceptionHandling {

--- a/src/main/kotlin/kr/io/snuhbmilab/carediaryserverv2/common/constants/Role.kt
+++ b/src/main/kotlin/kr/io/snuhbmilab/carediaryserverv2/common/constants/Role.kt
@@ -1,7 +1,7 @@
 package kr.io.snuhbmilab.carediaryserverv2.common.constants
 
 enum class Role {
-    USER, ADMIN;
+    USER, ADMIN, CARE_MANAGER;
 
     val authority: String = "ROLE_${name.uppercase()}"
 }

--- a/src/main/kotlin/kr/io/snuhbmilab/carediaryserverv2/common/properties/VerificationCodeProperties.kt
+++ b/src/main/kotlin/kr/io/snuhbmilab/carediaryserverv2/common/properties/VerificationCodeProperties.kt
@@ -1,0 +1,11 @@
+package kr.io.snuhbmilab.carediaryserverv2.common.properties
+
+import org.springframework.boot.context.properties.ConfigurationProperties
+import org.springframework.stereotype.Component
+
+@Component
+@ConfigurationProperties(prefix = "verification-code")
+data class VerificationCodeProperties(
+    var admin: String = "",
+    var careManager: String = "",
+)

--- a/src/main/kotlin/kr/io/snuhbmilab/carediaryserverv2/domain/user/dto/request/UserRegisterRequest.kt
+++ b/src/main/kotlin/kr/io/snuhbmilab/carediaryserverv2/domain/user/dto/request/UserRegisterRequest.kt
@@ -7,6 +7,7 @@ import kr.io.snuhbmilab.carediaryserverv2.domain.user.entity.User
 import kr.io.snuhbmilab.carediaryserverv2.domain.user.entity.UserInformation
 import java.time.LocalDate
 import java.time.YearMonth
+import java.util.UUID
 
 @Schema(description = "회원가입 요청")
 data class UserRegisterRequest(
@@ -74,7 +75,7 @@ data class UserRegisterRequest(
     val socialWelfareServiceLabels: List<String>?,
 
     @Schema(description = "담당 관리자 ID", example = "550e8400-e29b-41d4-a716-446655440000")
-    val managerId: Long?,
+    val managerId: UUID?,
 
     @Schema(description = "총괄 관리자 인증 코드", example = "ABCD1234")
     val adminCode: String?,

--- a/src/main/kotlin/kr/io/snuhbmilab/carediaryserverv2/domain/user/dto/request/UserRegisterRequest.kt
+++ b/src/main/kotlin/kr/io/snuhbmilab/carediaryserverv2/domain/user/dto/request/UserRegisterRequest.kt
@@ -73,5 +73,9 @@ data class UserRegisterRequest(
     @Schema(description = "[환자 정보] 사회복지서비스 (다중 선택)", example = "[\"CAREGIVER_COST\", \"SPECIAL_DIET_PURCHASE\"]")
     val socialWelfareServiceLabels: List<String>?,
 
+    @Schema(description = "담당 관리자 ID", example = "550e8400-e29b-41d4-a716-446655440000")
     val managerId: Long?,
+
+    @Schema(description = "총괄 관리자 인증 코드", example = "ABCD1234")
+    val adminCode: String?,
 )

--- a/src/main/kotlin/kr/io/snuhbmilab/carediaryserverv2/domain/user/dto/request/UserRegisterRequest.kt
+++ b/src/main/kotlin/kr/io/snuhbmilab/carediaryserverv2/domain/user/dto/request/UserRegisterRequest.kt
@@ -72,4 +72,6 @@ data class UserRegisterRequest(
 
     @Schema(description = "[환자 정보] 사회복지서비스 (다중 선택)", example = "[\"CAREGIVER_COST\", \"SPECIAL_DIET_PURCHASE\"]")
     val socialWelfareServiceLabels: List<String>?,
+
+    val managerId: Long?,
 )

--- a/src/main/kotlin/kr/io/snuhbmilab/carediaryserverv2/domain/user/entity/User.kt
+++ b/src/main/kotlin/kr/io/snuhbmilab/carediaryserverv2/domain/user/entity/User.kt
@@ -4,13 +4,18 @@ import jakarta.persistence.Column
 import jakarta.persistence.Entity
 import jakarta.persistence.EnumType
 import jakarta.persistence.Enumerated
+import jakarta.persistence.FetchType
 import jakarta.persistence.GeneratedValue
 import jakarta.persistence.GenerationType
 import jakarta.persistence.Id
+import jakarta.persistence.JoinColumn
+import jakarta.persistence.ManyToOne
 import jakarta.persistence.Table
 import kr.io.snuhbmilab.carediaryserverv2.common.constants.PROVIDER_ID_PATTERN
 import kr.io.snuhbmilab.carediaryserverv2.common.constants.Role
 import kr.io.snuhbmilab.carediaryserverv2.common.entity.BaseTimeEntity
+import org.hibernate.annotations.OnDelete
+import org.hibernate.annotations.OnDeleteAction
 import java.time.LocalDate
 import java.util.UUID
 
@@ -54,7 +59,15 @@ class User(
     var termCount: Int = 0,
 
     @Column(name = "first_diary_date")
-    var firstDiaryDate: LocalDate? = null
+    var firstDiaryDate: LocalDate? = null,
+
+    @Column(name = "manager_id")
+    var managerId: Long? = null,
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "manager_id", insertable = false, updatable = false)
+    @OnDelete(action = OnDeleteAction.SET_NULL)
+    var manager: User? = null,
 ) : BaseTimeEntity() {
 
     fun register(
@@ -63,7 +76,8 @@ class User(
         gender: Gender,
         birthDate: LocalDate,
         address: String,
-        primaryDiagnosis: String?
+        primaryDiagnosis: String?,
+        managerId: Long? = null
     ) {
         this.name = name
         this.role = role
@@ -71,6 +85,7 @@ class User(
         this.birthDate = birthDate
         this.address = address
         this.primaryDiagnosis = primaryDiagnosis
+        this.managerId = managerId
     }
 
     fun isRegistered(): Boolean = name != null

--- a/src/main/kotlin/kr/io/snuhbmilab/carediaryserverv2/domain/user/entity/User.kt
+++ b/src/main/kotlin/kr/io/snuhbmilab/carediaryserverv2/domain/user/entity/User.kt
@@ -62,7 +62,7 @@ class User(
     var firstDiaryDate: LocalDate? = null,
 
     @Column(name = "manager_id")
-    var managerId: Long? = null,
+    var managerId: UUID? = null,
 
     @ManyToOne(fetch = FetchType.LAZY)
     @JoinColumn(name = "manager_id", insertable = false, updatable = false)
@@ -77,7 +77,7 @@ class User(
         birthDate: LocalDate,
         address: String,
         primaryDiagnosis: String?,
-        managerId: Long? = null
+        managerId: UUID? = null
     ) {
         this.name = name
         this.role = role

--- a/src/main/kotlin/kr/io/snuhbmilab/carediaryserverv2/domain/user/entity/User.kt
+++ b/src/main/kotlin/kr/io/snuhbmilab/carediaryserverv2/domain/user/entity/User.kt
@@ -90,7 +90,7 @@ class User(
 
     fun isRegistered(): Boolean = name != null
 
-    fun isAdmin(): Boolean = role == Role.ADMIN
+    fun isAdminOrManager(): Boolean = role == Role.ADMIN || role == Role.CARE_MANAGER
 
     fun addScaleQuestionTermCount() {
         scaleQuestionTermCount++

--- a/src/main/kotlin/kr/io/snuhbmilab/carediaryserverv2/domain/user/exception/UserErrorCode.kt
+++ b/src/main/kotlin/kr/io/snuhbmilab/carediaryserverv2/domain/user/exception/UserErrorCode.kt
@@ -8,5 +8,6 @@ enum class UserErrorCode(
     override val message: String,
 ) : ErrorCode {
     USER_NOT_FOUND(HttpStatus.NOT_FOUND, "존재하지 않는 사용자 정보입니다."),
-    USER_INFORMATION_NOT_FOUND(HttpStatus.NOT_FOUND, "존재하지 않는 사용자 부가 정보입니다.")
+    USER_INFORMATION_NOT_FOUND(HttpStatus.NOT_FOUND, "존재하지 않는 사용자 부가 정보입니다."),
+    INVALID_VERIFICATION_CODE(HttpStatus.NOT_FOUND, "유효하지 않은 인증 코드입니다.")
 }

--- a/src/main/kotlin/kr/io/snuhbmilab/carediaryserverv2/domain/user/facade/UserFacade.kt
+++ b/src/main/kotlin/kr/io/snuhbmilab/carediaryserverv2/domain/user/facade/UserFacade.kt
@@ -1,9 +1,13 @@
 package kr.io.snuhbmilab.carediaryserverv2.domain.user.facade
 
 import kr.io.snuhbmilab.carediaryserverv2.auth.jwt.service.JwtProvider
+import kr.io.snuhbmilab.carediaryserverv2.common.constants.Role
+import kr.io.snuhbmilab.carediaryserverv2.common.exception.BusinessException
+import kr.io.snuhbmilab.carediaryserverv2.common.properties.VerificationCodeProperties
 import kr.io.snuhbmilab.carediaryserverv2.domain.user.dto.request.UserRegisterRequest
 import kr.io.snuhbmilab.carediaryserverv2.domain.user.dto.response.CurrentUserResponse
 import kr.io.snuhbmilab.carediaryserverv2.domain.user.dto.response.UserRegisterResponse
+import kr.io.snuhbmilab.carediaryserverv2.domain.user.exception.UserErrorCode
 import kr.io.snuhbmilab.carediaryserverv2.domain.user.service.UserInformationService
 import kr.io.snuhbmilab.carediaryserverv2.domain.user.service.UserService
 import org.springframework.stereotype.Service
@@ -15,11 +19,16 @@ import java.util.UUID
 class UserFacade(
     private val userService: UserService,
     private val userInformationService: UserInformationService,
-    private val jwtProvider: JwtProvider
+    private val jwtProvider: JwtProvider,
+    private val verificationCodeProperties: VerificationCodeProperties,
 ) {
     @Transactional
     fun register(userId: UUID, request: UserRegisterRequest): UserRegisterResponse {
         val user = userService.findById(userId)
+
+        if (request.role == Role.ADMIN || request.role == Role.CARE_MANAGER) {
+            validateVerificationCode(request.role, request.adminCode)
+        }
 
         user.register(
             request.name,
@@ -27,10 +36,11 @@ class UserFacade(
             request.gender,
             request.birthDate,
             request.address,
-            request.primaryDiagnosis
+            request.primaryDiagnosis,
+            request.managerId
         )
 
-        if (!user.isAdmin()) {
+        if (!user.isAdminOrManager()) {
             userInformationService.create(
                 user = user,
                 educationBeforeOnset = request.educationBeforeOnset,
@@ -56,9 +66,20 @@ class UserFacade(
         return UserRegisterResponse.from(accessToken)
     }
 
+    private fun validateVerificationCode(role: Role, adminCode: String?) {
+        val expectedCode = when (role) {
+            Role.ADMIN -> verificationCodeProperties.admin
+            Role.CARE_MANAGER -> verificationCodeProperties.careManager
+            else -> throw IllegalStateException()
+        }
+        if (adminCode != expectedCode) {
+            throw BusinessException(UserErrorCode.INVALID_VERIFICATION_CODE)
+        }
+    }
+
     fun getMe(userId: UUID): CurrentUserResponse {
         val user = userService.findById(userId)
-        val userInformation = if (user.isAdmin()) null else userInformationService.findByUserId(userId)
+        val userInformation = if (user.isAdminOrManager()) null else userInformationService.findByUserId(userId)
 
         return CurrentUserResponse.of(user, userInformation)
     }

--- a/src/main/kotlin/kr/io/snuhbmilab/carediaryserverv2/domain/user/repository/UserRepository.kt
+++ b/src/main/kotlin/kr/io/snuhbmilab/carediaryserverv2/domain/user/repository/UserRepository.kt
@@ -1,5 +1,6 @@
 package kr.io.snuhbmilab.carediaryserverv2.domain.user.repository
 
+import kr.io.snuhbmilab.carediaryserverv2.common.constants.Role
 import kr.io.snuhbmilab.carediaryserverv2.domain.user.entity.User
 import org.springframework.data.jpa.repository.JpaRepository
 import org.springframework.data.jpa.repository.Query
@@ -11,6 +12,10 @@ interface UserRepository : JpaRepository<User, UUID> {
     fun findAllByFirstDiaryDateIsNotNullAndTermCountGreaterThan(minTermCount: Int): List<User>
     fun findByEmailAndSocialProviderId(email: String, socialProviderId: User.SocialProviderId): User?
     fun findAllByNameIsNotNull(): List<User>
+    fun findAllByNameIsNotNullAndRole(role: Role): List<User>
+
+    @Query("SELECT u FROM User u WHERE u.name IS NOT NULL AND u.role = :role AND u.manager.id = :managerId")
+    fun findAllRegisteredByRoleAndManagerId(role: Role, managerId: UUID): List<User>
 
     @Query("SELECT COUNT(u) FROM User u WHERE u.createdAt >= :startDateTime")
     fun countByCreatedAtAfter(startDateTime: LocalDateTime): Long

--- a/src/main/kotlin/kr/io/snuhbmilab/carediaryserverv2/domain/user/service/UserService.kt
+++ b/src/main/kotlin/kr/io/snuhbmilab/carediaryserverv2/domain/user/service/UserService.kt
@@ -43,6 +43,11 @@ class UserService(
 
     fun findAllRegistered(): List<User> = userRepository.findAllByNameIsNotNull()
 
+    fun findAllByRole(role: Role): List<User> = userRepository.findAllByNameIsNotNullAndRole(role)
+
+    fun findAllByRoleAndManagerId(role: Role, managerId: UUID): List<User> =
+        userRepository.findAllRegisteredByRoleAndManagerId(role, managerId)
+
     fun countAll(): Long = userRepository.count()
 
     fun countByCreatedAtAfter(startDateTime: LocalDateTime): Long =

--- a/src/main/resources/application-dev.yml
+++ b/src/main/resources/application-dev.yml
@@ -109,3 +109,7 @@ aws:
     model-input-queue-url: ${AWS_SQS_MODEL_INPUT_QUEUE_URL}
     model-output-queue-url: ${AWS_SQS_MODEL_OUTPUT_QUEUE_URL}
     region: ${AWS_REGION:ap-northeast-2}
+
+verification-code:
+  admin: ${VERIFICATION_CODE_ADMIN}
+  care-manager: ${VERIFICATION_CODE_CARE_MANAGER}

--- a/src/main/resources/application-prod.yml
+++ b/src/main/resources/application-prod.yml
@@ -109,3 +109,7 @@ aws:
     model-input-queue-url: ${AWS_SQS_MODEL_INPUT_QUEUE_URL}
     model-output-queue-url: ${AWS_SQS_MODEL_OUTPUT_QUEUE_URL}
     region: ${AWS_REGION:ap-northeast-2}
+
+verification-code:
+  admin: ${VERIFICATION_CODE_ADMIN}
+  care-manager: ${VERIFICATION_CODE_CARE_MANAGER}


### PR DESCRIPTION
## #️⃣연관된 이슈

> ex) #이슈번호, #이슈번호

#62 

## 📝작업 내용

> 이번 PR에서 작업한 내용을 간략히 설명해주세요(이미지 첨부 가능)

  중간관리자(CARE_MANAGER) 역할 기능 구현                                 
   
  1. 회원가입 시 인증 코드 검증                                           
                                                            
  - ADMIN, CARE_MANAGER 역할로 회원가입 시 application.yml의 verification-code와 요청의 adminCode를 비교
  - 불일치 시 INVALID_VERIFICATION_CODE (404) 응답

  변경 파일:
  - VerificationCodeProperties.kt (신규) - yml 인증 코드 바인딩
  - UserErrorCode.kt - INVALID_VERIFICATION_CODE 에러 코드 추가
  - UserFacade.kt - validateVerificationCode() private 메서드로 검증 로직 추가

  2. 관리자 사용자 목록 조회 역할별 분기
 
  - ADMIN → USER 역할의 전체 사용자 목록 조회
  - CARE_MANAGER → 자신이 담당하는 (managerId가 본인인) USER만 조회

  변경 파일:
  - UserRepository.kt - findAllByNameIsNotNullAndRole(), findAllRegisteredByRoleAndManagerId() 추가
  - UserService.kt - findAllByRole(), findAllByRoleAndManagerId() 추가
  - AdminUserFacade.kt - findAllUsers(userId) 역할별 분기 처리
  - AdminUserApi.kt / AdminUserController.kt - @UserId 파라미터 추가


### 스크린샷 (선택)

## 💬리뷰 요구사항(선택)

> 리뷰어가 특별히 봐주었으면 하는 부분이 있다면 작성해주세요
>
> ex) 메서드 XXX의 이름을 더 잘 짓고 싶은데 혹시 좋은 명칭이 있을까요?


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * 케어 매니저(CARE_MANAGER) 역할 추가
  * 관리자·케어매니저 등록 시 인증 코드 검증 도입 (환경 변수로 코드 구성)
  * 회원 가입 시 매니저 지정 가능 및 매니저가 배정된 사용자 관리 지원

* **Refactor**
  * 관리자 기능 접근 범위 확대: 케어 매니저도 관련 관리 엔드포인트 이용 가능
  * 사용자 목록 조회가 역할·매니저 기준으로 제공되도록 개선
<!-- end of auto-generated comment: release notes by coderabbit.ai -->